### PR TITLE
Use the latest PostgreSQL release

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Instant search across devices, clients, and events from the top navigation bar.
 | **Maps** | Leaflet |
 | **Terminal** | xterm.js |
 | **Backend** | Node.js, Express, TypeScript |
-| **Primary DB** | PostgreSQL 15 |
+| **Primary DB** | PostgreSQL (latest) |
 | **Time-series DB** | InfluxDB 2.7 |
 | **Cache / Queue** | Redis 7, BullMQ |
 | **Real-time** | Socket.IO |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       start_period: 30s
 
   postgres:
-    image: postgres:15-alpine
+    image: pgautoupgrade/pgautoupgrade:latest
     environment:
       POSTGRES_DB: mikrotik_manager
       POSTGRES_USER: mikrotik


### PR DESCRIPTION
This uses the "automatic upgrade" PostgreSQL repository, so people don't need to manually upgrade their databases over the years.