### PR TITLE
fix(topology): stop infinite render loop crashing the Topology page (#37)

### DIFF
--- a/frontend/src/pages/TopologyPage.tsx
+++ b/frontend/src/pages/TopologyPage.tsx
@@ -516,10 +516,17 @@ export default function TopologyPage() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['topology'] }),
   });
 
+  // Depend on the stable `.mutate` function rather than the whole mutation object.
+  // TanStack Query recreates the mutation result object on every render but keeps
+  // `.mutate` referentially stable, so this keeps handleDeleteManual stable too.
+  // Depending on the whole object would make handleDeleteManual — and therefore the
+  // `graph` memo and the node/edge sync effect below — re-run on every render,
+  // causing an infinite setNodes/setEdges loop (React error #185).
+  const deleteManualLinkMutate = deleteManualLinkMutation.mutate;
   const handleDeleteManual = useCallback((edgeId: string) => {
     const id = parseInt(edgeId);
-    if (!isNaN(id)) deleteManualLinkMutation.mutate(id);
-  }, [deleteManualLinkMutation]);
+    if (!isNaN(id)) deleteManualLinkMutate(id);
+  }, [deleteManualLinkMutate]);
 
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);


### PR DESCRIPTION
## Summary

Fixes #37 — the **Topology page crashes on load** with `Minified React error #185` ("Maximum update depth exceeded"), thrown from inside React Flow's `setNodes`. The page is an infinite render loop.

## Root cause

A reactivity chain driven by an unstable dependency:

1. `deleteManualLinkMutation` (TanStack Query `useMutation`) returns a **new object reference on every render** — it carries mutation state like `isPending`.
2. `handleDeleteManual` listed that whole object as its `useCallback` dependency, so it got a **new identity every render**.
3. The `graph` `useMemo` depends on `handleDeleteManual`, so `graph` **rebuilt every render** into a new object.
4. The effect that syncs the graph into React Flow (`setNodes(graph.nodes); setEdges(graph.edges)`) is keyed on `graph`, so it **fired every render** → state update → re-render → back to step 1 → **infinite loop → React #185**.

This was latent and got surfaced by the React 18 → 19 + dependency bump in v0.11.11.

## Fix

Depend on the referentially-stable `.mutate` function instead of the whole mutation object. TanStack Query v5 recreates the result object each render but keeps `.mutate` stable, so `handleDeleteManual` stays stable, `graph` only rebuilds when `data`/`connectMode` actually change, and the sync effect stops looping.

```diff
-  const handleDeleteManual = useCallback((edgeId: string) => {
-    const id = parseInt(edgeId);
-    if (!isNaN(id)) deleteManualLinkMutation.mutate(id);
-  }, [deleteManualLinkMutation]);
+  const deleteManualLinkMutate = deleteManualLinkMutation.mutate;
+  const handleDeleteManual = useCallback((edgeId: string) => {
+    const id = parseInt(edgeId);
+    if (!isNaN(id)) deleteManualLinkMutate(id);
+  }, [deleteManualLinkMutate]);
```

(An earlier `useRef`-to-latest approach was rejected by the repo's `eslint-plugin-react-hooks` v7 rule `react-hooks/refs`, which forbids writing a ref during render. The `.mutate` approach is cleaner and lint-clean.)

## Testing

- `tsc --noEmit` — clean
- `eslint src/pages/TopologyPage.tsx` — clean (only pre-existing `security/detect-object-injection` warnings, unrelated)
- `npm run build` — succeeds
- Full local Docker stack (`docker compose up -d --build`) against 4 real devices: **Topology page now renders without React #185** (verified in Firefox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)